### PR TITLE
Update chdman installation instructions to use rom-tools formulae

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ If you don't have Homebrew installed, open Terminal and run:
 
 Follow the on-screen instructions. After installation, you may need to add Homebrew to your PATH. The installer will provide instructions specific to your Mac.
 
-### Step 2: Install MAME (includes chdman)
+### Step 2: Install rom-tools (includes chdman)
 
-Once Homebrew is installed, install MAME which includes chdman:
+Once Homebrew is installed, install rom-tools which includes chdman:
 
 ```bash
-brew install mame
+brew install rom-tools
 ```
 
-This will download and install MAME along with all its command-line tools, including chdman.
+This will download and install rom-tools along with chdman and other ROM management utilities.
 
 ### Step 3: Verify Installation
 

--- a/Swift-CHD/TROUBLESHOOTING.md
+++ b/Swift-CHD/TROUBLESHOOTING.md
@@ -39,7 +39,7 @@ Add `CHDMan_Mac_GUI.entitlements` to your project:
 which chdman
 
 # If not found, install via Homebrew
-brew install mame
+brew install rom-tools
 
 # Verify installation
 /opt/homebrew/bin/chdman --version  # Apple Silicon


### PR DESCRIPTION
Changed Homebrew installation command from 'brew install mame' to 'brew install rom-tools' in documentation. The chdman tool is included in the rom-tools formulae in Homebrew, not the mame formulae.

Updated files:
- README.md: Installation instructions (Step 2)
- Swift-CHD/TROUBLESHOOTING.md: Troubleshooting verification steps